### PR TITLE
Support quoted-printable content-transfer-encoding

### DIFF
--- a/parsemail.go
+++ b/parsemail.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"mime"
 	"mime/multipart"
+	"mime/quotedprintable"
 	"net/mail"
 	"strings"
 	"time"
@@ -417,6 +418,8 @@ func decodeContent(content io.Reader, encoding string) (io.Reader, error) {
 		return content, nil
 	case "":
 		return content, nil
+	case "quoted-printable":
+		return quotedprintable.NewReader(content), nil
 	default:
 		return nil, fmt.Errorf("unknown encoding: %s", encoding)
 	}

--- a/parsemail_test.go
+++ b/parsemail_test.go
@@ -428,6 +428,30 @@ So, "Hello".`,
 			htmlBody:  "<div dir=\"ltr\">👍</div>",
 			textBody:  "👍",
 		},
+		15: {
+			contentType: `text/plain; charset="utf-8"`,
+			mailData:    quotedPrintableContent,
+			textBody:    "Hello, Gophers!",
+			subject:     "Saying Hello",
+			from: []mail.Address{
+				{
+					Name:    "John Doe",
+					Address: "jdoe@machine.example",
+				},
+			},
+			sender: mail.Address{
+				Name:    "Michael Jones",
+				Address: "mjones@machine.example",
+			},
+			to: []mail.Address{
+				{
+					Name:    "Mary Smith",
+					Address: "mary@example.net",
+				},
+			},
+			messageID: "1234@local.machine.example",
+			date:      parseDate("Fri, 21 Nov 1997 09:55:06 -0600"),
+		},
 	}
 
 	for index, td := range testData {
@@ -994,4 +1018,18 @@ Content-Transfer-Encoding: base64
 PGRpdiBkaXI9Imx0ciI+8J+RjTwvZGl2Pgo=
 
 --000000000000ab2e1f05a26de586--
+`
+
+// This is encocded with quoted printable for "Hello, Gophers!"
+var quotedPrintableContent = `MIME-Version: 1.0
+From: John Doe <jdoe@machine.example>
+Sender: Michael Jones <mjones@machine.example>
+To: Mary Smith <mary@example.net>
+Subject: Saying Hello
+Date: Fri, 21 Nov 1997 09:55:06 -0600
+Message-ID: <1234@local.machine.example>
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+=48=65=6C=6C=6F=2C=20=47=6F=70=68=65=72=73=21
 `


### PR DESCRIPTION
Thanks for maintaining this fork, it's been awesome. I wanted to contribute back a fix I have.

The following email from a `ubuntu` box's unattended upgrade process will fail to parse: 

```
Subject: unattended-upgrades result for ubuntu-utilities: True
From: Unattended-upgrades ubuntu-utilities <blah@signal.bridge>
To: blah@signal.bridge
Auto-Submitted: auto-generated
MIME-Version: 1.0
Content-Type: text/plain; charset="utf-8"
Content-Transfer-Encoding: quoted-printable
Message-Id: <20210728060743.F41AB480221@ubuntu-utilities.localdomain>
Date: Wed, 28 Jul 2021 06:07:43 +0000 (UTC)

Unattended upgrade returned: True

Packages that were upgraded:
 ubuntu-advantage-tools=20
```

This PR adds support for `quoted-printable` to support it. I'm using this in https://github.com/lawrencegripper/signald-smtp-bridge.